### PR TITLE
BUGFIX: Fix a typo in queue options docs

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -31,7 +31,7 @@ Neos:
 #              passive: false
 #              durable: false
 #              exclusive: false
-#              autoDelte: true
+#              autoDelete: true
 #              nowait: false
 #              arguments: []
 #              ticket: null

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Flowpack:
               durable: true
               # multiple worker should be able to consume a queue at the same time
               exclusive: false
-              autoDelte: false
+              autoDelete: false
 
             client:
               host: localhost
@@ -94,7 +94,7 @@ Flowpack:
               exchangeName: 't3n'
               # the queue should be durable and don't delete itself
               durable: true
-              autoDelte: false
+              autoDelete: false
               # several worker are allowed per queue
               exclusive: false
 


### PR DESCRIPTION
Found a typo in the configuration documentation