### PR TITLE
BUGFIX: Close RabbitMq connection in destructor

### DIFF
--- a/Classes/Queue/RabbitQueue.php
+++ b/Classes/Queue/RabbitQueue.php
@@ -255,7 +255,7 @@ class RabbitQueue implements QueueInterface
         $this->channel->queue_purge($this->queueName);
     }
 
-    public function shutdownObject(): void
+    public function __destruct()
     {
         $this->channel->close();
         $this->connection->close();


### PR DESCRIPTION
Many Flow Packages will try to submit a message in
a shutdownObject() method. If the queue connection
is also closed in a shutdownObject(), the success
depends on the package load order.

In my case I'm having problems with Neos.EventSourcing: https://github.com/neos/Neos.EventSourcing/blob/2d7642fa88488b47ebd307b03d0a2b09ebf39ffb/Classes/EventStore/EventListenerTrigger/EventListenerTrigger.php#L87