### PR TITLE
FEATURE: Allow configuration of RabbitMq heartbeat

### DIFF
--- a/Classes/Queue/RabbitQueue.php
+++ b/Classes/Queue/RabbitQueue.php
@@ -70,8 +70,24 @@ class RabbitQueue implements QueueInterface
         $vhost = $clientOptions['vhost'] ?? '/';
         $insist = isset($clientOptions['insist']) ? (bool) $clientOptions['insist'] : false;
         $loginMethod = isset($clientOptions['loginMethod']) ? (string) $clientOptions['loginMethod'] : 'AMQPLAIN';
+        $heartbeat = (int) ($clientOptions['heartbeat'] ?? 0);
 
-        $this->connection = new AMQPStreamConnection($host, $port, $username, $password, $vhost, $insist, $loginMethod, null, 'en_US', 3.0, 3.0, null, true, 0);
+        $this->connection = new AMQPStreamConnection(
+            $host,
+            $port,
+            $username,
+            $password,
+            $vhost,
+            $insist,
+            $loginMethod,
+            null,
+            'en_US',
+            3.0,
+            3.0,
+            null,
+            true,
+            $heartbeat
+        );
         $this->channel = $this->connection->channel();
 
         // a worker should only get one message at a time

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Flowpack:
               port: 5672
               username: guest
               password: guest
+              heartbeat: 60 # Sets RabbitMQ connection heartbeat to 60 seconds
 
       queues:
         producer-import:


### PR DESCRIPTION
Adds a client configuration parameter to configure the connection heartbeat for RabbitMQ. Previously, this value was 0, disabling heartbeats completely.

The recommended value for RabbitMQ is 60 seconds, specified [here](https://www.rabbitmq.com/configure.html). Maybe this should be the default here as well?